### PR TITLE
Fix strapi container restart loop by adding CMD to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,3 +26,5 @@ USER node
 RUN npm run build
 
 EXPOSE 1337
+
+CMD ["npm", "run", "start"]


### PR DESCRIPTION
## Summary
- The "Udpated node" commit (cac3874) bumped the base image to Node 20 and switched `NODE_ENV` to `production`, but in the process dropped the trailing `CMD ["npm", "run", "develop"]` line from the Dockerfile.
- With no `CMD` (and `node:20-alpine` having no useful default), the container started, immediately exited, and was relaunched by `restart: unless-stopped` — matching the screenshot's `strapi (...) restarting Restarting (0) 5 seconds` state.
- Re-added a `CMD` invoking `npm run start` (the production script in `package.json`), which is the correct entrypoint now that `NODE_ENV=production`.

## Test plan
- [ ] Redeploy the Dokploy `strapi` service and confirm the container reaches `running` instead of `restarting`.
- [ ] Tail `strapi` logs and confirm Strapi boots, connects to `strapiDB`, and serves on port 1363.
- [ ] Hit the admin URL / API to confirm the app responds.

https://claude.ai/code/session_01HFLdFK18bFAStLePRzW3b7

---
_Generated by [Claude Code](https://claude.ai/code/session_01HFLdFK18bFAStLePRzW3b7)_