### PR TITLE
Prefer IPv4 in wait-for-db and dump /etc/hosts for diagnostics

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -5,37 +5,62 @@
 
 DB_HOST="${DATABASE_HOST:-strapiDB}"
 DB_PORT="${DATABASE_PORT:-3306}"
-MAX_ATTEMPTS=30
+MAX_ATTEMPTS=15
 SLEEP_SECS=2
 
 log() {
   printf '[wait-for-db] %s\n' "$1"
 }
 
+log "================================================================"
 log "target=${DB_HOST}:${DB_PORT} (DATABASE_CLIENT=${DATABASE_CLIENT:-<unset>})"
+log "container hostname=$(hostname 2>/dev/null)"
+log "/etc/hosts:"
+sed 's/^/    /' /etc/hosts 2>/dev/null || log "    <unreadable>"
+log "/etc/resolv.conf:"
+sed 's/^/    /' /etc/resolv.conf 2>/dev/null || log "    <unreadable>"
+log "Initial name resolution:"
+log "  getent ahostsv4 ${DB_HOST}:"
+getent ahostsv4 "$DB_HOST" 2>&1 | head -5 | sed 's/^/    /' || log "    <none>"
+log "  getent ahostsv6 ${DB_HOST}:"
+getent ahostsv6 "$DB_HOST" 2>&1 | head -5 | sed 's/^/    /' || log "    <none>"
+log "================================================================"
+
+# Warn loudly if the target resolves to loopback - that's never a working
+# DB inside a container, and the most common cause is DATABASE_HOST=localhost
+# in .env or the strapi container's own hostname colliding with the DB name.
+v4_first=$(getent ahostsv4 "$DB_HOST" 2>/dev/null | awk '{print $1}' | head -n1)
+case "${v4_first}" in
+  127.*|::1)
+    log "WARNING: ${DB_HOST} resolves to loopback (${v4_first}). The DB is"
+    log "         not reachable from inside this container at that address."
+    log "         Check that DATABASE_HOST in .env points at the DB service"
+    log "         name (e.g. strapiDB) and that this container is on the"
+    log "         same docker network as the DB container."
+    ;;
+esac
 
 i=1
 while [ "$i" -le "$MAX_ATTEMPTS" ]; do
-  resolved=$(getent hosts "$DB_HOST" 2>/dev/null | awk '{print $1}' | head -n1)
+  v4_ip=$(getent ahostsv4 "$DB_HOST" 2>/dev/null | awk '{print $1}' | head -n1)
 
-  if [ -n "$resolved" ]; then
-    if nc -z -w 3 "$DB_HOST" "$DB_PORT" 2>/dev/null; then
-      log "ok: ${DB_HOST} -> ${resolved}:${DB_PORT} (attempt ${i})"
-      exec "$@"
-    fi
-    log "attempt ${i}/${MAX_ATTEMPTS}: dns=${resolved} tcp=failed"
-  else
-    log "attempt ${i}/${MAX_ATTEMPTS}: dns=<unresolved> tcp=skipped"
+  if [ -n "$v4_ip" ]; then
+    case "${v4_ip}" in
+      127.*) ;;  # don't bother probing loopback
+      *)
+        if nc -z -w 3 "$v4_ip" "$DB_PORT" 2>/dev/null; then
+          log "ok: ${DB_HOST} -> ${v4_ip}:${DB_PORT} (attempt ${i})"
+          exec "$@"
+        fi
+        ;;
+    esac
   fi
 
+  log "attempt ${i}/${MAX_ATTEMPTS}: v4=${v4_ip:-<unresolved>} tcp=failed"
   i=$((i + 1))
   sleep "$SLEEP_SECS"
 done
 
-log "FAILED after ${MAX_ATTEMPTS} attempts. Diagnostics:"
-log "  hostname: $(hostname 2>/dev/null)"
-log "  own ip:   $(hostname -i 2>/dev/null)"
-log "  resolv.conf:"
-sed 's/^/    /' /etc/resolv.conf 2>/dev/null || log "    <unreadable>"
-log "Starting Strapi anyway so mysql2 emits its native error..."
+log "FAILED after ${MAX_ATTEMPTS} attempts. Starting Strapi anyway so"
+log "mysql2 emits its native error."
 exec "$@"


### PR DESCRIPTION
## Summary
The previous diagnostic showed `strapiDB` is resolving to `::1` (IPv6 loopback) inside the strapi container — the container is trying to connect to itself, which is why mysql2 times out. Two likely causes I can't yet distinguish:

1. **`DATABASE_HOST=localhost` in `.env`** — would resolve to `::1` and you'd see this exact symptom. Easy fix: unset it or set to `strapiDB`.
2. **The strapi container's own hostname is `strapiDB`** — Docker would add a self-entry to `/etc/hosts` that wins over Docker's DNS for the DB service. Would happen if Dokploy somehow set hostname `strapiDB` on the strapi container, or if both containers ended up with the same name.

This PR makes the next failure self-diagnosing and also makes the probe IPv4-preferring (which mysql2 itself does by default), so an IPv6 loopback entry doesn't short-circuit a working v4 path.

## What changes
- Dump `/etc/hosts`, `/etc/resolv.conf`, the container's `hostname`, and both `getent ahostsv4` / `ahostsv6` results at startup. After the next deploy, the very first log block will say exactly where the `::1` mapping is coming from.
- Switch the probe from `getent hosts` (which can return v6 first) to `getent ahostsv4`. The probe now connects to the resolved IPv4 address directly rather than the hostname, so we bypass any v6 entry in `/etc/hosts`.
- If the resolved address is `127.*` or `::1`, log a loud `WARNING` block with the most likely fix instead of spinning silently for 60s.
- Drop max attempts 30 → 15 for faster feedback when this really is broken.

## What to look for after deploy
The startup block will show:
- **What `target=` actually is** — confirms whether `.env` is overriding `DATABASE_HOST`.
- **The strapi container's `hostname`** — if it's `strapiDB`, that's the root cause.
- **`/etc/hosts`** — the exact line that maps `strapiDB` to `::1` (if any).
- **`getent ahostsv4 strapiDB`** — if this returns a real v4 like `172.x.x.x` and the probe succeeds, the old IPv6-first lookup was the whole problem and Strapi will now boot.

If the probe succeeds with a real v4 address, the rest of the diagnostic block tells you what config to clean up; if it still fails, the `/etc/hosts` and `target=` lines will tell us which of the two causes above is in play and the next PR can apply the actual fix.

## Test plan
- [ ] Redeploy in Dokploy.
- [ ] Capture the full `[wait-for-db]` startup block (everything between the `====` lines) and the first 3 attempt lines.
- [ ] If Strapi boots: 🎉. Investigate the `.env` / hostname situation to clean it up.
- [ ] If it still fails: share the startup block — next PR can do the targeted fix.

https://claude.ai/code/session_01HFLdFK18bFAStLePRzW3b7

---
_Generated by [Claude Code](https://claude.ai/code/session_01HFLdFK18bFAStLePRzW3b7)_