### PR TITLE
Capture nc verbose error and extend wait-for-db budget

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -5,7 +5,7 @@
 
 DB_HOST="${DATABASE_HOST:-strapiDB}"
 DB_PORT="${DATABASE_PORT:-3306}"
-MAX_ATTEMPTS=15
+MAX_ATTEMPTS=60
 SLEEP_SECS=2
 
 log() {
@@ -44,11 +44,14 @@ i=1
 while [ "$i" -le "$MAX_ATTEMPTS" ]; do
   v4_ip=$(getent ahostsv4 "$DB_HOST" 2>/dev/null | awk '{print $1}' | head -n1)
 
+  probe_err=""
   if [ -n "$v4_ip" ]; then
     case "${v4_ip}" in
-      127.*) ;;  # don't bother probing loopback
+      127.*) probe_err="resolved to loopback, skipped" ;;
       *)
-        if nc -z -w 3 "$v4_ip" "$DB_PORT" 2>/dev/null; then
+        probe_err=$(nc -v -w 3 -z "$v4_ip" "$DB_PORT" 2>&1 </dev/null)
+        probe_exit=$?
+        if [ "$probe_exit" -eq 0 ]; then
           log "ok: ${DB_HOST} -> ${v4_ip}:${DB_PORT} (attempt ${i})"
           exec "$@"
         fi
@@ -56,7 +59,9 @@ while [ "$i" -le "$MAX_ATTEMPTS" ]; do
     esac
   fi
 
-  log "attempt ${i}/${MAX_ATTEMPTS}: v4=${v4_ip:-<unresolved>} tcp=failed"
+  # busybox nc puts the failure reason on stderr; collapse to one line
+  probe_err_short=$(printf '%s' "$probe_err" | tr '\n' ' ' | sed 's/  */ /g')
+  log "attempt ${i}/${MAX_ATTEMPTS}: v4=${v4_ip:-<unresolved>} tcp=failed (${probe_err_short:-<no detail>})"
   i=$((i + 1))
   sleep "$SLEEP_SECS"
 done


### PR DESCRIPTION
## Summary
DNS now works (`strapiDB` → `172.25.0.2`, same network as strapi at `172.25.0.4`) but TCP to `:3306` is still failing. Could be either:

1. `Connection refused` — mysqld isn't listening (still booting, crashed, or bound to loopback only).
2. `Operation timed out` — network policy or routing dropping packets.

The previous probe ate `nc`'s stderr so the log just said `tcp=failed`. This PR captures the verbose error per attempt, and bumps the retry budget from 15 → 60 attempts (~5 min worst case) to allow a first-run mysqld bootstrap to finish.

## What to look for after deploy
The per-attempt line will now look like one of:

- `tcp=failed (... Connection refused)` → mysqld isn't accepting on `172.25.0.2:3306`. Next step: check the `strapiDB` container logs and confirm mysqld is up and listening on `0.0.0.0:3306`.
- `tcp=failed (... timed out)` or `... no route to host` → packets aren't reaching the DB container. Could be Dokploy-specific network isolation between the bridge networks (strapi is on both 172.19.x and 172.25.x; we don't know which one strapiDB joined).
- `tcp=failed (... resolved to loopback ...)` → DNS regressed.
- `ok: strapiDB -> 172.25.0.2:3306` → mysqld finally became ready and Strapi boots. In that case the only issue was startup ordering / slow first-run init.

Also worth checking once: `docker compose logs strapiDB` (or Dokploy's equivalent) for the line `[Server] /usr/sbin/mysqld: ready for connections.` — if that never appears, mysqld is the actual problem.

## Test plan
- [ ] Redeploy in Dokploy.
- [ ] Wait up to ~2 min for the wait-for-db loop.
- [ ] Share one `tcp=failed (...)` line so we can pick the next fix, or confirm Strapi booted.

https://claude.ai/code/session_01HFLdFK18bFAStLePRzW3b7

---
_Generated by [Claude Code](https://claude.ai/code/session_01HFLdFK18bFAStLePRzW3b7)_