### PR TITLE
Add network dump and dual-port probe to wait-for-db

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -24,12 +24,26 @@ log "  getent ahostsv4 ${DB_HOST}:"
 getent ahostsv4 "$DB_HOST" 2>&1 | head -5 | sed 's/^/    /' || log "    <none>"
 log "  getent ahostsv6 ${DB_HOST}:"
 getent ahostsv6 "$DB_HOST" 2>&1 | head -5 | sed 's/^/    /' || log "    <none>"
+log "Network interfaces:"
+(ip -o -4 addr show 2>/dev/null || ifconfig 2>/dev/null) | sed 's/^/    /' || log "    <unavailable>"
+log "Routing table:"
+(ip -4 route 2>/dev/null || route -n 2>/dev/null) | sed 's/^/    /' || log "    <unavailable>"
+v4_first=$(getent ahostsv4 "$DB_HOST" 2>/dev/null | awk '{print $1}' | head -n1)
+if [ -n "$v4_first" ]; then
+  log "One-shot probes to ${DB_HOST} (${v4_first}):"
+  # 3306 = mysqld, 33060 = mysqlx (also listening per server logs). If 33060
+  # succeeds while 3306 times out, mysqld is selectively unreachable. If both
+  # time out, the issue is reachability of the host itself.
+  for probe_port in 3306 33060; do
+    result=$(nc -v -w 3 -z "$v4_first" "$probe_port" 2>&1 </dev/null)
+    log "  :${probe_port} -> $(printf '%s' "$result" | tr '\n' ' ' | sed 's/  */ /g')"
+  done
+fi
 log "================================================================"
 
 # Warn loudly if the target resolves to loopback - that's never a working
 # DB inside a container, and the most common cause is DATABASE_HOST=localhost
 # in .env or the strapi container's own hostname colliding with the DB name.
-v4_first=$(getent ahostsv4 "$DB_HOST" 2>/dev/null | awk '{print $1}' | head -n1)
 case "${v4_first}" in
   127.*|::1)
     log "WARNING: ${DB_HOST} resolves to loopback (${v4_first}). The DB is"


### PR DESCRIPTION
## Summary
TCP probe now reports `Operation timed out` instead of "Connection refused", while mysqld's own logs from `strapiDB` show it's listening cleanly on `0.0.0.0:3306`. The strapi container is on three networks (`172.25.x`, `172.19.x`, `10.0.1.x` via Tailscale) and DNS resolves `strapiDB` to `172.25.0.2`. Same `/16` but packets aren't getting through — most likely strapi is sending out the wrong interface, or strapiDB is on a sibling docker network with an overlapping subnet.

This PR adds one-shot diagnostics at container start so the next log will tell us:
- Which network strapi actually believes it's on (`ip -4 addr` + `ip -4 route`).
- Whether MySQL's other port (`33060`, mysqlx) is reachable. If `33060` succeeds while `3306` times out → mysqld is selectively unreachable (unlikely but worth knowing). If **both** time out → the host itself is unreachable from this container, which means we have a docker network problem and need a compose-level fix.

## What to look for after deploy
The startup block will now include:
```
[wait-for-db] Network interfaces:
    inet 172.25.0.x/16 ...
    inet 172.19.0.x/16 ...
    inet 10.0.1.x/32 ...   (tailscale)
[wait-for-db] Routing table:
    default via ...
    172.25.0.0/16 dev ...
    172.19.0.0/16 dev ...
[wait-for-db] One-shot probes to strapiDB (172.25.0.2):
    :3306 -> nc: ... <result>
    :33060 -> nc: ... <result>
```

If **both ports time out**, the most likely fix is a compose networking change (e.g. removing the explicit `Strapi` user-defined network and attaching both services to the same Dokploy-managed network). Share the probe output and I'll open the targeted fix PR.

## Test plan
- [ ] Redeploy in Dokploy.
- [ ] Share the new `Network interfaces`, `Routing table`, and `One-shot probes` lines from the startup block.

https://claude.ai/code/session_01HFLdFK18bFAStLePRzW3b7

---
_Generated by [Claude Code](https://claude.ai/code/session_01HFLdFK18bFAStLePRzW3b7)_