### PR TITLE
Pin Strapi network to 10.55.0.0/24 to avoid Dokploy subnet collision

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,3 +85,10 @@ networks:
   strapi:
     name: Strapi
     driver: bridge
+    ipam:
+      config:
+        # Pinned to an uncommon /24 to avoid colliding with Dokploy-managed
+        # bridges (which default to 172.x.x.x). When two bridges share a
+        # subnet, containers can't reach each other across them even though
+        # their addresses look local.
+        - subnet: 10.55.0.0/24


### PR DESCRIPTION
## Summary
The wait-for-db dump from your last deploy nailed down the root cause. From the strapi container:

```
Routing table:
    default via 172.25.0.1 dev eth0
    172.25.0.0/16 dev eth0 scope link  src 172.25.0.4
    172.19.0.0/16 dev eth2 scope link  src 172.19.0.2
    ...
One-shot probes to strapiDB (172.25.0.2):
    :3306  -> nc: ... Operation timed out
    :33060 -> nc: ... Operation timed out
```

Both 3306 **and** 33060 time out. mysqld in the `strapiDB` container is listening on `0.0.0.0:3306` per the MySQL logs you shared earlier, so the DB itself is fine. The strapi container's own routing table says `172.25.0.0/16` is local to `eth0`, but ARP never gets an answer.

That's the classic signature of **two different docker bridges both using `172.25.0.0/16`**. Compose let Docker auto-pick a subnet for the user-defined `Strapi` network and it collided with a Dokploy-managed bridge. Strapi's `eth0` is on one of them, `strapiDB` is on the other, the addresses *look* local but there's no L2 path → silent timeout.

## Fix
Pin the `Strapi` bridge to `10.55.0.0/24` — well outside Docker's default `172.16.0.0/12` pool and the typical `192.168.x.x` defaults — so it can't collide with whatever Dokploy is creating. After the redeploy:

- Both containers get addresses like `10.55.0.x` on the only bridge that owns that subnet.
- DNS for `strapiDB` resolves to its `10.55.0.x`.
- ARP works → TCP works → mysql2 connects → Strapi boots.

## Important: redeploy may need network recreation
Docker doesn't always recreate a network whose name already exists. If after merging the wait-for-db log still shows `172.25.0.x`, that means the old `Strapi` network is still in place and Dokploy reused it. In that case, run:

```sh
docker network rm Strapi
```

on the Dokploy host and then redeploy. (Stop the containers first if needed — they hold a reference to the network.)

## What to look for after deploy
The wait-for-db block should now show:
```
Network interfaces:
    inet 10.55.0.x/24 brd 10.55.0.255 scope global eth0
Routing table:
    10.55.0.0/24 dev eth0 scope link  src 10.55.0.x
    ...
One-shot probes to strapiDB (10.55.0.y):
    :3306 -> ... open
    :33060 -> ... open
```
…followed by `ok: strapiDB -> 10.55.0.y:3306` and Strapi booting cleanly.

## Test plan
- [ ] Merge.
- [ ] Redeploy in Dokploy.
- [ ] If wait-for-db still reports a `172.25.x` address for `strapiDB`, run `docker network rm Strapi` on the host and redeploy.
- [ ] Confirm Strapi boots and `:1363` responds.

https://claude.ai/code/session_01HFLdFK18bFAStLePRzW3b7

---
_Generated by [Claude Code](https://claude.ai/code/session_01HFLdFK18bFAStLePRzW3b7)_